### PR TITLE
fix class variable scope

### DIFF
--- a/lib/image-search.js
+++ b/lib/image-search.js
@@ -25,25 +25,26 @@ module.exports = class ImageSearch {
                 return err;
             });
     }
+    
+    function getOptions(query, options) {
+        if (!options) {
+            options = {};
+        }
+        let result = {
+            q: query.replace(/\s/g, '+'),
+            searchType: 'image',
+            cx: this.cseId,
+            key: this.apiKey
+        };
+        if (options.page) {
+            result.start = options.page;
+        }
+        return queryStirng.stringify(result);
+    }
+    
 };
 
 /* private helper function */
-function getOptions(query, options) {
-    if (!options) {
-        options = {};
-    }
-    let result = {
-        q: query.replace(/\s/g, '+'),
-        searchType: 'image',
-        cx: this.cseId,
-        key: this.apiKey
-    };
-    if (options.page) {
-        result.start = options.page;
-    }
-    return queryStirng.stringify(result);
-}
-
 function buildResult(res) {
     return (res.body.items || []).map((item) => {
         return {


### PR DESCRIPTION
This is a fix for isssue [#1](https://github.com/abhi11210646/Image-search-google/issues/1)

cause: getOptions accessing this.cseId from outside the imageSearch class

TypeError: Cannot read property 'cseId' of undefined
at getOptions (/home/ubuntu/workspace/image_searchak/node_modules/image-search-google/lib/image-search.js:39:17)

fix: move getOptions inside the imageSearch class