### PR TITLE
add num to query options

### DIFF
--- a/lib/image-search.js
+++ b/lib/image-search.js
@@ -41,6 +41,9 @@ function getOptions(query, options) {
     if (options.page) {
         result.start = options.page;
     }
+    if(options.num){
+        result.num = options.num;
+    }
     return queryStirng.stringify(result);
 }
 


### PR DESCRIPTION
num: Number of search results to return.
Valid values are integers between 1 and 10, inclusive.
reference: [google cse](https://developers.google.com/custom-search/json-api/v1/reference/cse/list)